### PR TITLE
Add missing characters to word_characters

### DIFF
--- a/languages/clojure/config.toml
+++ b/languages/clojure/config.toml
@@ -9,4 +9,5 @@ brackets = [
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
 ]
-word_characters = ["-"]
+# See https://clojure.org/reference/reader#_reader_forms
+word_characters = ["*", "+", "!", "-", "_", "'", "?", "<", ">", "="]


### PR DESCRIPTION
Add all characters allowed within a Clojure symbol as per: https://clojure.org/reference/reader#_reader_forms