### PR TITLE
Add comment language injections

### DIFF
--- a/languages/clojure/injections.scm
+++ b/languages/clojure/injections.scm
@@ -1,0 +1,2 @@
+((comment) @content
+  (#set! "language" "comment"))


### PR DESCRIPTION
With the Comment extension installed, this will allow comments starting with TODO, FIXME, etc to be styled